### PR TITLE
improve protection when attempting to delete appointments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,22 @@
 Changes
 =======
 
+0.2.25 (unreleased)
+===================
+
+
+0.2.24
+======
+- enforce consistent ordering by ``timepoint``, ``visit_code_sequence``
+- in ``delete_for_subject_after_date``, bypass ``schedule`` filter with ``is_offstudy``
+
 0.2.23
 ======
 - in ``delete_for_subject_after_date``, add ``visit_schedule_name`` and ``schedule_name``
   to query of future appts (gh-4)
 - increment timepoint decimal for interim (continuation) appointments (gh-4)
+- enforce consistent ordering by ``timepoint``, ``visit_code_sequence``
+- in ``delete_for_subject_after_date``, bypass ``schedule`` filter with ``is_offstudy``
 
 5 feb 2019
 ==========

--- a/edc_appointment/admin_site.py
+++ b/edc_appointment/admin_site.py
@@ -9,3 +9,4 @@ class EdcAppointmentAdminSite(AdminSite):
 
 
 edc_appointment_admin = EdcAppointmentAdminSite(name="edc_appointment_admin")
+edc_appointment_admin.disable_action('delete_selected')

--- a/edc_appointment/apps.py
+++ b/edc_appointment/apps.py
@@ -27,7 +27,7 @@ class AppConfig(DjangoAppConfig):
         from .signals import (
             create_appointments_on_post_save,
             appointment_post_save,
-            delete_appointments_on_post_delete,
+            appointments_on_pre_delete,
         )
 
         sys.stdout.write(f"Loading {self.verbose_name} ...\n")
@@ -48,7 +48,8 @@ class AppConfig(DjangoAppConfig):
                 c for c in self.configurations if getattr(c, attr) == value
             ][0]
         except IndexError:
-            keys = [(c.name, c.related_visit_model) for c in self.configurations]
+            keys = [(c.name, c.related_visit_model)
+                    for c in self.configurations]
             raise EdcAppointmentAppConfigError(
                 f"AppointmentConfig not found. Got {name or related_visit_model}. "
                 f'Expected one of {keys}. See edc_appointment.AppConfig "configurations".'

--- a/edc_appointment/managers.py
+++ b/edc_appointment/managers.py
@@ -1,10 +1,13 @@
 from django.db import models
 from django.db.models.deletion import ProtectedError
-
-from edc_visit_schedule.site_visit_schedules import site_visit_schedules
+from edc_visit_schedule import site_visit_schedules
 
 
 class AppointmentManagerError(Exception):
+    pass
+
+
+class SubjectOnScheduleError(Exception):
     pass
 
 
@@ -45,7 +48,8 @@ class AppointmentManager(models.Manager):
         except AttributeError:
             options.update(subject_identifier=subject_identifier)
             try:
-                visit_schedule_name, schedule_name = visit_schedule_name.split(".")
+                visit_schedule_name, schedule_name = visit_schedule_name.split(
+                    ".")
                 options.update(
                     visit_schedule_name=visit_schedule_name, schedule_name=schedule_name
                 )
@@ -155,7 +159,8 @@ class AppointmentManager(models.Manager):
         schedule = site_visit_schedules.get_visit_schedule(
             options.get("visit_schedule_name")
         ).schedules.get(options.get("schedule_name"))
-        options.update(visit_code=self.get_visit_code("next", schedule, **kwargs))
+        options.update(visit_code=self.get_visit_code(
+            "next", schedule, **kwargs))
         try:
             next_appointment = self.filter(**options).order_by(
                 "timepoint", "visit_code_sequence"
@@ -174,7 +179,8 @@ class AppointmentManager(models.Manager):
         schedule = site_visit_schedules.get_visit_schedule(
             options.get("visit_schedule_name")
         ).schedules.get(options.get("schedule_name"))
-        options.update(visit_code=self.get_visit_code("previous", schedule, **kwargs))
+        options.update(visit_code=self.get_visit_code(
+            "previous", schedule, **kwargs))
         try:
             previous_appointment = (
                 self.filter(**options)
@@ -205,7 +211,8 @@ class AppointmentManager(models.Manager):
         valid_ops = ["gt", "gte"]
         if op and op not in valid_ops:
             formatted = ", ".join(valid_ops)
-            raise TypeError(f"Allowed lookup operators are {formatted}. Got {op}.")
+            raise TypeError(
+                f"Allowed lookup operators are {formatted}. Got {op}.")
         op = "gte" if op is None else op
 
         # prepare options
@@ -215,7 +222,8 @@ class AppointmentManager(models.Manager):
         }
         if not is_offstudy:
             try:
-                visit_schedule_name, schedule_name = visit_schedule_name.split(".")
+                visit_schedule_name, schedule_name = visit_schedule_name.split(
+                    ".")
             except (ValueError, AttributeError):
                 pass
             if not schedule_name or not visit_schedule_name:

--- a/edc_appointment/model_mixins/appointment_methods_model_mixin.py
+++ b/edc_appointment/model_mixins/appointment_methods_model_mixin.py
@@ -17,7 +17,8 @@ class AppointmentMethodsModelMixin(models.Model):
     @classmethod
     def related_visit_model_attr(cls):
         app_config = django_apps.get_app_config("edc_appointment")
-        appointment_config = app_config.get_configuration(name=cls._meta.label_lower)
+        appointment_config = app_config.get_configuration(
+            name=cls._meta.label_lower)
         return appointment_config.related_visit_model_attr
 
     @classmethod

--- a/edc_appointment/signals.py
+++ b/edc_appointment/signals.py
@@ -1,5 +1,7 @@
-from django.db.models.signals import post_save, post_delete
+from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
+from django.db.models.deletion import ProtectedError
+from edc_visit_schedule import off_schedule_or_raise, OnScheduleError
 
 
 @receiver(post_save, weak=False, dispatch_uid="create_appointments_on_post_save")
@@ -27,9 +29,17 @@ def appointment_post_save(sender, instance, raw, created, using, **kwargs):
                 raise
 
 
-@receiver(post_delete, weak=False, dispatch_uid="delete_appointments_on_post_delete")
-def delete_appointments_on_post_delete(sender, instance, using, **kwargs):
-    try:
-        instance.delete_unused_appointments()
-    except AttributeError:
-        pass
+@receiver(pre_delete, weak=False, dispatch_uid="appointments_on_pre_delete")
+def appointments_on_pre_delete(sender, instance, using, **kwargs):
+    pass
+#     try:
+#         opts = dict(
+#             subject_identifier=instance.subject_identifier,
+#             report_datetime=instance.appt_datetime,
+#             visit_schedule_name=instance.visit_schedule_name,
+#             schedule_name=instance.schedule_name)
+#     except AttributeError:
+#         pass
+#     else:
+#         if instance.visit_code_sequence == 0:
+#             off_schedule_or_raise(**opts)

--- a/edc_appointment/tests/models.py
+++ b/edc_appointment/tests/models.py
@@ -5,7 +5,7 @@ from edc_base.model_mixins import BaseUuidModel
 from edc_identifier.model_mixins import NonUniqueSubjectIdentifierFieldMixin
 from edc_locator.model_mixins import LocatorModelMixin
 from edc_registration.model_mixins import UpdatesOrCreatesRegistrationModelMixin
-from edc_visit_schedule.model_mixins import OnScheduleModelMixin
+from edc_visit_schedule.model_mixins import OnScheduleModelMixin, OffScheduleModelMixin
 from edc_visit_tracking.model_mixins import VisitModelMixin
 
 from ..models import Appointment
@@ -49,7 +49,17 @@ class OnScheduleOne(OnScheduleModelMixin, BaseUuidModel):
     pass
 
 
+class OffScheduleOne(OffScheduleModelMixin, BaseUuidModel):
+
+    pass
+
+
 class OnScheduleTwo(OnScheduleModelMixin, BaseUuidModel):
+
+    pass
+
+
+class OffScheduleTwo(OffScheduleModelMixin, BaseUuidModel):
 
     pass
 

--- a/edc_appointment/tests/test_appointment_form.py
+++ b/edc_appointment/tests/test_appointment_form.py
@@ -34,7 +34,8 @@ class TestAppointmentForm(TestCase):
         site_visit_schedules.register(visit_schedule=visit_schedule2)
         self.helper = self.helper_cls(
             subject_identifier=self.subject_identifier,
-            now=arrow.Arrow.fromdatetime(datetime(2017, 1, 7), tzinfo="UTC").datetime,
+            now=arrow.Arrow.fromdatetime(
+                datetime(2017, 1, 7), tzinfo="UTC").datetime,
         )
 
     def test_get_previous(self):
@@ -76,7 +77,8 @@ class TestAppointmentForm(TestCase):
         try:
             AppointmentFormValidator(cleaned_data={})
         except ModelFormFieldValidatorError as e:
-            self.fail(f"ModelFormFieldValidatorError unexpectedly raised. Got {e}")
+            self.fail(
+                f"ModelFormFieldValidatorError unexpectedly raised. Got {e}")
 
     def test_visit_report_sequence(self):
         """Asserts a sequence error is raised if previous visit
@@ -145,7 +147,8 @@ class TestAppointmentForm(TestCase):
                 schedule_name=appointments[i].schedule_name,
             )
 
-        appointments = Appointment.objects.all().order_by("appt_datetime")
+        appointments = Appointment.objects.all().order_by(
+            "timepoint", "visit_code_sequence")
 
         # appointments is
         # 1000.0, 1000.1, 1000.2 2000.0, 3000.0, 4000.0

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,4 @@ deps =
 python =
   3.7: py37-django21
   3.7: py37-django22
-  3.7: py37-djangotrunk
+; 3.7: py37-djangotrunk


### PR DESCRIPTION
* block all users from deleting appointments with visit_code_sequence=0

* override ModelAdmin ``has_delete_permission`` to allow users with permissions to delete interim appointments

* disable admin action ``delete_selected``

* add pre_delete signal to block illegal appointment deletion