### PR TITLE
Remove deprecated django.utils.datetime_safe usage

### DIFF
--- a/edc_appointment/creators/appointment_creator.py
+++ b/edc_appointment/creators/appointment_creator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -8,7 +9,6 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.utils import IntegrityError
-from django.utils.datetime_safe import datetime
 from django.utils.timezone import is_naive
 from edc_facility.facility import Facility, FacilityError
 from edc_visit_schedule.utils import is_baseline


### PR DESCRIPTION
Current/replaced usage only used for type hinting.

Was deprecated in Django 4.0, and is to be removed in Django 5.0

See also:
- https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-5-0
- https://code.djangoproject.com/ticket/29600